### PR TITLE
ci: 本番デプロイ用ワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Run lint
         run: pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run lint
+        run: pnpm lint
+
+      - name: Build web app
+        run: pnpm --filter web build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment:
+      name: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Deploy Worker API
+        working-directory: apps/api
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: pnpm exec wrangler deploy
+
+      - name: Build web app
+        run: pnpm --filter web build
+
+      - name: Deploy Cloudflare Pages
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
+          directory: apps/web/.svelte-kit/cloudflare
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          branch: main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,10 +30,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Deploy Worker API
         working-directory: apps/api

--- a/apps/web/src/lib/api/fetcher.ts
+++ b/apps/web/src/lib/api/fetcher.ts
@@ -1,4 +1,4 @@
-import { PUBLIC_API_BASE_URL } from '$env/static/public';
+import { env as publicEnv } from '$env/dynamic/public';
 
 export type FetcherConfig<TVariables> = {
   url: string;
@@ -29,7 +29,7 @@ function buildUrl(url: string, params?: Record<string, unknown>, baseURL?: strin
   return queryString ? `${hasBase}?${queryString}` : hasBase;
 }
 
-const DEFAULT_BASE_URL = PUBLIC_API_BASE_URL || '/api';
+const DEFAULT_BASE_URL = publicEnv.PUBLIC_API_BASE_URL || '/api';
 
 function mergeBaseAndPath(baseURL: string, path: string) {
   if (!/^https?:/i.test(baseURL)) {

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -107,6 +107,8 @@ Continuous integration and deployment are automated via two workflows under `.gi
 - `ci.yml` — runs on every pull request and push to `main`. It installs dependencies, runs `pnpm lint`, and builds the web client. Treat this job as required for PR merge protection.
 - `deploy.yml` — runs on pushes to `main` (and on manual `workflow_dispatch`). It deploys the Worker (`wrangler deploy`) and publishes the Pages project via `cloudflare/pages-action`.
 
+> Note: Because the repository does not track `pnpm-lock.yaml`, the workflows skip package-manager caching and run `pnpm install` without `--frozen-lockfile`. If you add a lock file later, re-enable caching by setting `cache: pnpm` in `actions/setup-node` and switch the install command to `pnpm install --frozen-lockfile`.
+
 ### Required GitHub secrets
 
 | Secret | Description | Scope |
@@ -116,6 +118,19 @@ Continuous integration and deployment are automated via two workflows under `.gi
 | `CLOUDFLARE_PAGES_PROJECT` | Cloudflare Pages project name (e.g. `lunch-picker-web`). | Required by Pages action |
 
 Set these values in the repository’s **Settings → Secrets and variables → Actions**. Optionally add them as organization secrets if multiple repos share the same infrastructure.
+
+#### How to create the Cloudflare API token
+
+1. Log in to the Cloudflare dashboard and open **My Profile → API Tokens**.
+2. Click **Create Token** → **Create Custom Token**.
+3. Add these permissions:
+   - Workers KV Storage → Edit
+   - Workers Scripts → Edit
+   - Pages → Edit
+4. Under **Account Resources**, select your target account (or “All accounts” if you prefer).
+5. Create the token and copy the generated string once. Store it as the `CLOUDFLARE_API_TOKEN` GitHub secret.
+6. From the same account overview page, copy the **Account ID**; this becomes `CLOUDFLARE_ACCOUNT_ID`.
+7. In the Cloudflare Pages project settings, note the project slug (e.g. `lunch-picker-web`) and store it as `CLOUDFLARE_PAGES_PROJECT`.
 
 ### Manual rollback
 


### PR DESCRIPTION
## 概要
- GitHub Actions に `ci.yml` を追加し、PR/`main` への push で `pnpm lint` と Web ビルドを実行
- `deploy.yml` を追加し、`main` への push および手動トリガーで Workers デプロイ＆Cloudflare Pages 発行を自動化
- `docs/deployment.md` に必要な GitHub Secrets とロールバック手順を追記

## テスト
- ワークフローは追加のみで手動実行なし

Closes #22