### PR TITLE
feat: limit maximum search radius to 1200m

### DIFF
--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -73,11 +73,11 @@
         id="radius"
         type="range"
         min="300"
-        max="3000"
+        max="1200"
         step="100"
         bind:value={radius}
         aria-valuemin="300"
-        aria-valuemax="3000"
+        aria-valuemax="1200"
         aria-valuenow={radius}
         aria-label="検索範囲（メートル）"
         class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer accent-indigo-600"


### PR DESCRIPTION
## Summary
- Reduce maximum search radius from 3000m to 1200m (approximately 15-minute walk)
- Improves search result consistency when using cuisine filters
- Reduces Google Places API costs

## Problem
When the search radius was too large (e.g., 3000m):
1. Google Places API returns max 20 results from within the radius
2. With a larger radius, nearby restaurants (e.g., 1.5km away) might not be included in those 20 results
3. When cuisine filters are applied, those excluded restaurants never appear in final results
4. User reported: "2km radius showed a restaurant, but 3km radius didn't show it"

## Solution
Limit maximum radius to 1200m:
- Approximately 15-minute one-way walk (24-minute round trip at 80m/min)
- More realistic for lunch breaks
- Higher density of results within the radius
- Better chance of cuisine-filtered results being present in API's 20-item response
- Lower API usage

## Changes
- UI slider max value: 3000m → 1200m
- aria-valuemax attribute updated to match

## Test plan
- [x] Run `pnpm lint` - passed
- [x] Run `pnpm --filter web build` - passed
- [x] Verify slider max value is 1200m in UI
- [ ] Manual testing: Search with 1200m radius should show more consistent results with cuisine filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)